### PR TITLE
Better output formatting + ability to stop/remove boxes

### DIFF
--- a/jiffybox/api.py
+++ b/jiffybox/api.py
@@ -276,6 +276,10 @@ class Box(_JiffyResource):
         res = self._put(endpoint=self.id, data={'status': 'START'})
         return type(self)(res, self.api)
 
+    def stop(self):
+        res = self._put(endpoint=self.id, data={'status': 'SHUTDOWN'})
+        return type(self)(res, self.api)
+
     @property
     def public_ips(self):
         return self.ips.get('public', None)

--- a/jiffybox/api.py
+++ b/jiffybox/api.py
@@ -317,6 +317,10 @@ class JiffyBox(object):
         """
         List all boxes in the account.
 
+        .. warning:: As noted in the API docs, this call is fairly expensive
+                     and should not be used to monitor status with a high
+                     refresh rate.
+
         :rtype: List of :class:`boxes <Box>`
         """
         return Box.all(self)

--- a/jiffybox/cli.py
+++ b/jiffybox/cli.py
@@ -62,7 +62,6 @@ def box():
 
 
 @box.command('list')
-@click.confirmation_option(prompt='This may take some time')
 def list_boxes():
     print_data(API.boxes())
 

--- a/jiffybox/cli.py
+++ b/jiffybox/cli.py
@@ -56,24 +56,24 @@ def jiffybox(api_key, verbose, output_format, pager):
     USE_PAGER = pager
 
 
-@jiffybox.group('box', help='Manage boxes')
+@jiffybox.group('box', help='Manages boxes')
 def box():
     pass
 
 
-@box.command('list')
+@box.command('list', help='Lists all boxes in account')
 def list_boxes():
     print_data(API.boxes())
 
 
-@box.command('show')
+@box.command('show', help='Shows a single box')
 @click.argument('id')
 def show_box(id):
     box = API.box(id)
     print_data([box])
 
 
-@box.command('create')
+@box.command('create', help='Creates and start a new box')
 @click.argument('name')
 @click.argument('plan')
 @click.argument('distribution')
@@ -86,7 +86,7 @@ def create_box(name, plan, distribution, sshkey):
     print_data([box])
 
 
-@box.command('delete')
+@box.command('delete', help='Deletes a box')
 @click.argument('id')
 @click.option('--no-confirm', is_flag=True, default=False)
 def delete_box(id, no_confirm):
@@ -100,11 +100,11 @@ def delete_box(id, no_confirm):
             raise click.exceptions.RuntimeError('could not delete box')
 
 
-@jiffybox.command(help='Show a list of distributions')
+@jiffybox.command(help='Shows a list of distributions')
 def distributions():
     print_data(API.distributions())
 
 
-@jiffybox.command(help='Show a list of pricing plans')
+@jiffybox.command(help='Shows a list of pricing plans')
 def plans():
     print_data(API.plans())

--- a/jiffybox/cli.py
+++ b/jiffybox/cli.py
@@ -6,7 +6,6 @@ from click import echo, echo_via_pager
 
 from .api import JiffyBox
 
-
 API = None
 OUTPUT_FORMAT = None
 USE_PAGER = None
@@ -44,12 +43,13 @@ def print_data(data):
 
 @click.group()
 @click.version_option()
-@click.option('--api-key', envvar='JIFFYBOX_API_KEY',
+@click.option('--api-key',
+              envvar='JIFFYBOX_API_KEY',
               help='also read from JIFFYBOX_API_KEY',
               required=True)
 @click.option('-v', '--verbose', count=True)
-@click.option('--output-format', type=click.Choice(['plain', 'json',
-                                                    'json-pretty']))
+@click.option('--output-format',
+              type=click.Choice(['plain', 'json', 'json-pretty']))
 @click.option('--pager', is_flag=True)
 def jiffybox(api_key, verbose, output_format, pager):
     global API, OUTPUT_FORMAT, USE_PAGER
@@ -83,9 +83,12 @@ def show_box(id):
 @click.argument('distribution')
 @click.option('--sshkey/--no-sshkey', is_flag=True, default=True)
 def create_box(name, plan, distribution, sshkey):
-    box = API.create_box(name, plan, distribution=distribution,
+    box = API.create_box(name,
+                         plan,
+                         distribution=distribution,
                          use_sshkey=sshkey)
     print_data([box])
+
 
 @box.command('delete')
 @click.argument('id')
@@ -95,11 +98,11 @@ def delete_box(id, no_confirm):
         API.delete_box(id)
     else:
         box = API.box(id)
-        click.confirm(
-                'Really delete box {0} ({1})?'.format(id, box.name),
-                abort=True)
+        click.confirm('Really delete box {0} ({1})?'.format(id, box.name),
+                      abort=True)
         if not box.delete():
             raise click.exceptions.RuntimeError('could not delete box')
+
 
 @jiffybox.command()
 def distributions():

--- a/jiffybox/cli.py
+++ b/jiffybox/cli.py
@@ -20,7 +20,7 @@ def format_data(data):
     if OUTPUT_FORMAT == 'plain':
         for elem in data:
             echo('id: ' + str(elem.id))
-            for attr in elem._attributes.keys():
+            for attr in sorted(elem._attributes.keys()):
                 echo('  ' + attr + ': ' + str(getattr(elem, attr)))
 
     # FIXME id on top in json

--- a/jiffybox/cli.py
+++ b/jiffybox/cli.py
@@ -27,7 +27,7 @@ def format_data(data):
     elif OUTPUT_FORMAT == 'json':
         return '\n'.join([json.dumps(elem.json) for elem in data])
     elif OUTPUT_FORMAT == 'json-pretty':
-        return '\n'.join([json.dumps(elem.json, indent=True) for elem in data])
+        return '\n'.join([json.dumps(elem.json, indent=2) for elem in data])
 
 
 def output(data):

--- a/jiffybox/cli.py
+++ b/jiffybox/cli.py
@@ -19,9 +19,13 @@ def format_data(data):
     data = sort_data(data)
     if OUTPUT_FORMAT == 'plain':
         for elem in data:
-            echo('id: ' + str(elem.id))
+            header = None
+            if hasattr(elem, 'name') and hasattr(elem, 'id'):
+                header = '{}({})'.format(elem.name, elem.id)
+            if header:
+                echo(header)
             for attr in sorted(elem._attributes.keys()):
-                echo('  ' + attr + ': ' + str(getattr(elem, attr)))
+                echo('  {:21s}: {}'.format(attr, getattr(elem, attr)))
 
     # FIXME id on top in json
     elif OUTPUT_FORMAT == 'json':

--- a/jiffybox/cli.py
+++ b/jiffybox/cli.py
@@ -56,7 +56,7 @@ def jiffybox(api_key, verbose, output_format, pager):
     USE_PAGER = pager
 
 
-@jiffybox.group('box')
+@jiffybox.group('box', help='Manage boxes')
 def box():
     pass
 
@@ -100,11 +100,11 @@ def delete_box(id, no_confirm):
             raise click.exceptions.RuntimeError('could not delete box')
 
 
-@jiffybox.command()
+@jiffybox.command(help='Show a list of distributions')
 def distributions():
     print_data(API.distributions())
 
 
-@jiffybox.command()
+@jiffybox.command(help='Show a list of pricing plans')
 def plans():
     print_data(API.plans())

--- a/jiffybox/cli.py
+++ b/jiffybox/cli.py
@@ -5,6 +5,7 @@ import click
 from click import echo, echo_via_pager
 
 from .api import JiffyBox
+from .format import PlainFormatVisitor
 
 API = None
 OUTPUT_FORMAT = None
@@ -18,15 +19,7 @@ def sort_data(data):
 def format_data(data):
     data = sort_data(data)
     if OUTPUT_FORMAT == 'plain':
-        for elem in data:
-            header = None
-            if hasattr(elem, 'name') and hasattr(elem, 'id'):
-                header = '{}({})'.format(elem.name, elem.id)
-            if header:
-                echo(header)
-            for attr in sorted(elem._attributes.keys()):
-                echo('  {:21s}: {}'.format(attr, getattr(elem, attr)))
-
+        return '\n\n'.join(PlainFormatVisitor().visit(box) for box in data)
     # FIXME id on top in json
     elif OUTPUT_FORMAT == 'json':
         return '\n'.join([json.dumps(elem.json) for elem in data])

--- a/jiffybox/cli.py
+++ b/jiffybox/cli.py
@@ -62,7 +62,17 @@ def box():
 
 
 @box.command('list', help='Lists all boxes in account')
-def list_boxes():
+@click.option('--quiet',
+              '-q',
+              is_flag=True,
+              default=False,
+              help='Suppress warning at the start')
+def list_boxes(quiet):
+    if not quiet:
+        echo('Please use this API call sparingly; see '
+             'https://www.df.eu/fileadmin/user_upload/'
+             'jiffybox-api-dokumentation.pdf [pg. 10] for details.',
+             err=True)
     print_data(API.boxes())
 
 

--- a/jiffybox/format.py
+++ b/jiffybox/format.py
@@ -5,11 +5,6 @@ class PlainFormatVisitor(Visitor):
     def __init__(self):
         self.indent = 0
 
-    def visit_Box(self, node):
-        buf = "{}({}):".format(node.name, node.id)
-        buf += self.visit_object(node)
-        return buf
-
     def visit_dict(self, node):
         if not node:
             return ''
@@ -27,9 +22,15 @@ class PlainFormatVisitor(Visitor):
 
     def visit_object(self, node):
         if hasattr(node, '_attributes'):
+            buf = ''
+            if hasattr(node, 'name'):
+                buf += node.name
+            if hasattr(node, 'id'):
+                buf += '({})'.format(node.id)
             obj_dict = {
                 attr: getattr(node, attr)
                 for attr in node._attributes.keys()
             }
-            return self.visit(obj_dict)
+            buf += self.visit(obj_dict)
+            return buf
         return str(node)

--- a/jiffybox/format.py
+++ b/jiffybox/format.py
@@ -1,0 +1,32 @@
+from visitor import Visitor
+
+
+class PlainFormatVisitor(Visitor):
+    def __init__(self):
+        self.indent = 0
+
+    def visit_Box(self, node):
+        buf = "{}({}):".format(node.name, node.id)
+        buf += self.visit_object(node)
+        return buf
+
+    def visit_dict(self, node):
+        if not node:
+            return ''
+        buf = '\n'
+        self.indent += 2
+        parts = []
+        for k, v in sorted(node.items()):
+            parts.append(' ' * self.indent + '{}: {}'.format(k, self.visit(v)))
+        self.indent -= 2
+
+        return buf + '\n'.join(parts)
+
+    def visit_object(self, node):
+        if hasattr(node, '_attributes'):
+            obj_dict = {
+                attr: getattr(node, attr)
+                for attr in node._attributes.keys()
+            }
+            return self.visit(obj_dict)
+        return str(node)

--- a/jiffybox/format.py
+++ b/jiffybox/format.py
@@ -22,6 +22,9 @@ class PlainFormatVisitor(Visitor):
 
         return buf + '\n'.join(parts)
 
+    def visit_list(self, node):
+        return ', '.join(self.visit(child) for child in node)
+
     def visit_object(self, node):
         if hasattr(node, '_attributes'):
             obj_dict = {

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(name='jiffybox',
       ],
       extras_require={
           'cli': [
-              'click',
+              'click', 'visitor>=1.3.0'
           ],
       },
       entry_points='''


### PR DESCRIPTION
New output format:

```
apitest1(295748)
  activeProfile: None
  created: 2016-05-18 21:49:01
  host: vmhost-2-2-1-9
  id: 295748
  ips: 
    private: 10.1.31.4
    public: 134.119.17.112
  isBeingCopied: False
  manualBackupRunning: False
  metadata: 
  name: apitest1
  plan: CloudLevel 1(44)
    cpus: 1
    diskSizeInMB: 102400
    id: 44
    name: CloudLevel 1
    pricePerHour: 0.02
    pricePerHourFrozen: 0.005
    ramInMB: 2048
  recoverymodeActive: False
  running: False
  runningSince: None
  status: CREATING
```

Additionally, it is possible to remove running boxes thanks to the added `stop()` API method:

```
$ jiffybox box delete -f 295748
Really delete box 295748 (apitest1)? [y/N]: y
Waiting for box to become ready
Stopping box 295748 (apitest1)
Removed box 295748 (apitest1)
```
